### PR TITLE
修正在老版本Firefox中无法正确显示验证码窗口的bug

### DIFF
--- a/baiduyun.user.js
+++ b/baiduyun.user.js
@@ -50,6 +50,30 @@
     'unselected': '获取选中文件失败，请F5刷新重试！',
     'morethan2': '该方法不支持多文件下载！'
   };
+    
+  $.fn.dialogDrag = function () {
+    var mouseInitX, mouseInitY, dialogInitX, dialogInitY;
+    var screenWidth = document.body.clientWidth;
+    var $parent = this;
+    $('div.dialog-header', this).mousedown(function (event) {
+      mouseInitX = parseInt(event.pageX);
+      mouseInitY = parseInt(event.pageY);
+      dialogInitX = parseInt($parent.css('left').replace('px', ''));
+      dialogInitY = parseInt($parent.css('top').replace('px', ''));
+      $(this).mousemove(function (event) {
+        var tempX = dialogInitX + parseInt(event.pageX) - mouseInitX;
+        var tempY = dialogInitY + parseInt(event.pageY) - mouseInitY;
+        var width = parseInt($parent.css('width').replace('px', ''));
+        tempX = tempX < 0 ? 0 : tempX > screenWidth - width ? screenWidth - width : tempX;
+        tempY = tempY < 0 ? 0 : tempY;
+        $parent.css('left', tempX + 'px').css('top', tempY + 'px');
+      });
+    });
+    $('div.dialog-header', this).mouseup(function (event) {
+      $(this).unbind('mousemove');
+    });
+  };
+    
   $(function () {
     classMap['default-dom'] = ($('.icon-upload').parent().parent().parent().parent().parent().attr('class'));
     classMap['bar'] = ($('.icon-upload').parent().parent().parent().parent().attr('class'));
@@ -2032,29 +2056,6 @@
       shadow.hide();
     }
   }
-
-  $.fn.dialogDrag = function () {
-    var mouseInitX, mouseInitY, dialogInitX, dialogInitY;
-    var screenWidth = document.body.clientWidth;
-    var $parent = this;
-    $('div.dialog-header', this).mousedown(function (event) {
-      mouseInitX = parseInt(event.pageX);
-      mouseInitY = parseInt(event.pageY);
-      dialogInitX = parseInt($parent.css('left').replace('px', ''));
-      dialogInitY = parseInt($parent.css('top').replace('px', ''));
-      $(this).mousemove(function (event) {
-        var tempX = dialogInitX + parseInt(event.pageX) - mouseInitX;
-        var tempY = dialogInitY + parseInt(event.pageY) - mouseInitY;
-        var width = parseInt($parent.css('width').replace('px', ''));
-        tempX = tempX < 0 ? 0 : tempX > screenWidth - width ? screenWidth - width : tempX;
-        tempY = tempY < 0 ? 0 : tempY;
-        $parent.css('left', tempX + 'px').css('top', tempY + 'px');
-      });
-    });
-    $('div.dialog-header', this).mouseup(function (event) {
-      $(this).unbind('mousemove');
-    });
-  };
 
   (function() {
     var script = document.createElement("script");

--- a/baiduyun.user.js
+++ b/baiduyun.user.js
@@ -50,48 +50,6 @@
     'unselected': '获取选中文件失败，请F5刷新重试！',
     'morethan2': '该方法不支持多文件下载！'
   };
-    
-  $.fn.dialogDrag = function () {
-    var mouseInitX, mouseInitY, dialogInitX, dialogInitY;
-    var screenWidth = document.body.clientWidth;
-    var $parent = this;
-    $('div.dialog-header', this).mousedown(function (event) {
-      mouseInitX = parseInt(event.pageX);
-      mouseInitY = parseInt(event.pageY);
-      dialogInitX = parseInt($parent.css('left').replace('px', ''));
-      dialogInitY = parseInt($parent.css('top').replace('px', ''));
-      $(this).mousemove(function (event) {
-        var tempX = dialogInitX + parseInt(event.pageX) - mouseInitX;
-        var tempY = dialogInitY + parseInt(event.pageY) - mouseInitY;
-        var width = parseInt($parent.css('width').replace('px', ''));
-        tempX = tempX < 0 ? 0 : tempX > screenWidth - width ? screenWidth - width : tempX;
-        tempY = tempY < 0 ? 0 : tempY;
-        $parent.css('left', tempX + 'px').css('top', tempY + 'px');
-      });
-    });
-    $('div.dialog-header', this).mouseup(function (event) {
-      $(this).unbind('mousemove');
-    });
-  };
-    
-  $(function () {
-    classMap['default-dom'] = ($('.icon-upload').parent().parent().parent().parent().parent().attr('class'));
-    classMap['bar'] = ($('.icon-upload').parent().parent().parent().parent().attr('class'));
-
-    switch (detectPage()) {
-      case 'disk':
-        var panHelper = new PanHelper();
-        panHelper.init();
-        return;
-      case 'share':
-      case 's':
-        var panShareHelper = new PanShareHelper();
-        panShareHelper.init();
-        return;
-      default:
-        return;
-    }
-  });
 
   function slog(c1, c2, c3) {
     c1 = c1 ? c1 : '';
@@ -2056,6 +2014,48 @@
       shadow.hide();
     }
   }
+
+  $.fn.dialogDrag = function () {
+    var mouseInitX, mouseInitY, dialogInitX, dialogInitY;
+    var screenWidth = document.body.clientWidth;
+    var $parent = this;
+    $('div.dialog-header', this).mousedown(function (event) {
+      mouseInitX = parseInt(event.pageX);
+      mouseInitY = parseInt(event.pageY);
+      dialogInitX = parseInt($parent.css('left').replace('px', ''));
+      dialogInitY = parseInt($parent.css('top').replace('px', ''));
+      $(this).mousemove(function (event) {
+        var tempX = dialogInitX + parseInt(event.pageX) - mouseInitX;
+        var tempY = dialogInitY + parseInt(event.pageY) - mouseInitY;
+        var width = parseInt($parent.css('width').replace('px', ''));
+        tempX = tempX < 0 ? 0 : tempX > screenWidth - width ? screenWidth - width : tempX;
+        tempY = tempY < 0 ? 0 : tempY;
+        $parent.css('left', tempX + 'px').css('top', tempY + 'px');
+      });
+    });
+    $('div.dialog-header', this).mouseup(function (event) {
+      $(this).unbind('mousemove');
+    });
+  };
+
+  $(function () {
+    classMap['default-dom'] = ($('.icon-upload').parent().parent().parent().parent().parent().attr('class'));
+    classMap['bar'] = ($('.icon-upload').parent().parent().parent().parent().attr('class'));
+
+    switch (detectPage()) {
+      case 'disk':
+        var panHelper = new PanHelper();
+        panHelper.init();
+        return;
+      case 'share':
+      case 's':
+        var panShareHelper = new PanShareHelper();
+        panShareHelper.init();
+        return;
+      default:
+        return;
+    }
+  });
 
   (function() {
     var script = document.createElement("script");


### PR DESCRIPTION
这个脚本在我这里(Firefox 56)经常会出现点击“直接下载”或“下载链接”没反应的情况，一直以为是百度更新导致的，今天调了一下，发现是触发了百度的验证码验证的情况下，验证码对话框显示不出来；在2.2.3版上加了个try catch后(行号不变)，捕获到以下异常：

> TypeError: $dialog_div.dialogDrag is not a function
Stack trace:
createDialog@file:///C:/xxx/baiduyun.user.js:1822:7
Dialog@file:///C:/xxx/baiduyun.user.js:1965:14
PanShareHelper/this.init@file:///C:/xxx/baiduyun.user.js:1030:16
@file:///C:/xxx/baiduyun.user.js:65:9
i@file:///C:/xxx/jquery.min.js:2:27444
add@file:///C:/xxx/jquery.min.js:2:27748
n.fn.ready@file:///C:/xxx/jquery.min.js:2:29796
n.fn.init@file:///C:/xxx/jquery.min.js:2:25178
n@file:///C:/xxx/jquery.min.js:2:406
@file:///C:/xxx/baiduyun.user.js:53:3
@file:///C:/xxx/baiduyun.user.js:24:6
  baiduyun.user.js:2067:12

经过更多测试后发现，  jquery的$(function(){})内的callback居然在userscript的外层主函数执行完之前先执行了；而且这种情况不稳定，有时候是前者先执行，有时候是后者先执行完；导致有时候jquery的callback内跑到调用dialogDrag的时候外层还没把这个函数挂到$.fn上去；

怀疑是火狐老版本上的油猴机制问题，可能userscript是执行在一个后台线程上，而jquery的onready callback是执行在页面线程上，因为执行在不同的线程上造成了这个问题；因此我就把onready callback挪到主函数最后去以保证不出现执行顺序出问题的情况。