### PR TITLE
增加对 FireMonkey 支持

### DIFF
--- a/panlinker.user.js
+++ b/panlinker.user.js
@@ -584,10 +584,11 @@
 
         _getFidList() {
             let fidlist = [];
-            selectList.forEach(v => {
-                if (+v.isdir === 1) return;
-                fidlist.push(v.fs_id);
-            });
+            for (const v of selectList) {
+                if (+v.isdir !== 1) {
+                    fidlist.push(v.fs_id);
+                }
+            }
             return '[' + fidlist + ']';
         },
 
@@ -1021,7 +1022,7 @@
             try {
                 return require('system-core:context/context.js').instanceForSystem.list.getSelected();
             } catch (e) {
-                return document.querySelector('.wp-s-core-pan').__vue__.selectedList;
+                return unsafeWindow.document.querySelector('.wp-s-core-pan').__vue__.selectedList;
             }
         },
 


### PR DESCRIPTION
因为 FireMonkey 把脚本注入 userScript context，比（例如 ViolentMonkey 的 page context）有更严格的隔离，因此需要修改代码以支持。此代码应该并不影响 ViolentMonkey 中的行为。

参见 https://github.com/syhyz1990/baiduyun/issues/94